### PR TITLE
setup: change default installation location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
                 "add_to_path": False,
                 "all_users": True,
                 "install_icon": "icon.ico",
-                "initial_target_dir": r"[ProgramFilesFolder]\\TWLMagician"
+                "initial_target_dir": r"[LocalAppDataFolder]\\Programs\\TWLMagician"
             }},
     executables=executables
 )


### PR DESCRIPTION
The default installation location for TWLMagician is in Window's Program Files folder. This causes issues as trying to run TWLMagician as a normal user will crash the program with a permissions error. The user is required to run the application as an administrator to get it working.
<img width="1348" height="452" alt="image" src="https://github.com/user-attachments/assets/0506d291-f40e-4273-aa31-609f30c6527a" />


Changing the default installation location to C:\TWLMagician fixes the permissions error and will not require the user to run it as an administrator.

